### PR TITLE
Fix WEB_ORIGIN value

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,2 +1,2 @@
-WEB_ORIGIN=http://127.0.0.1:5173
+WEB_ORIGIN=http://localhost:3000
 DATABASE_URL=""


### PR DESCRIPTION
一つ間違いがあったので、修正しておきました。今の状態では何も影響しませんが。
タイピングゲームでの以下のコードのように、バックエンドにアクセスできるものを制限すると、今のままだとうまく動かなくなりそうだったので、修正しておきました。
https://github.com/ut-code/typing-game/blob/b72b0358303f0c28b0a17ffefa8de376ab7d9693/backend/main.js#L11

それと、今入ってるのは Vite 2 のようですが、Vite 4 にするとサーバーの URL が変わってるので、もし Vite をアップデートしたらもう一度変える必要がありそうです。