### PR TITLE
Fix Prettier setting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,3 @@
-/node_modules
 /.DS_Store
 /.env
-/.git
 dist

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 /.DS_Store
 /.env
 /.git
+dist


### PR DESCRIPTION
- `dist` がフォーマットされていたので、`.prettierignore` に追加しました。
- `.git` と `node_modules` はデフォルトで ignore されるので、設定を削除しました。
   > By default prettier ignores files in version control systems directories (".git", ".svn" and ".hg") and node_modules (if [--with-node-modules CLI option](https://prettier.io/docs/en/cli.html#--with-node-modules) not specified)
   
   https://prettier.io/docs/en/ignore.html