### PR TITLE
👹着々とスクレイピングを進めた

### DIFF
--- a/backend/prisma/crawl.py
+++ b/backend/prisma/crawl.py
@@ -51,7 +51,8 @@ def crawlRecipeUrls(search_word: str, pages_num: int) -> list[str]:
     recipe_urls = []
     # url = f"http://www.kyounoryouri.jp/search/recipe?keyword={search_word}&pg="
     # url = f"https://www.lettuceclub.net/recipe/search/{search_word}/p"
-    url = f"https://www.ebarafoods.com/recipe/results.html?q={search_word}&page="
+    # url = f"https://www.ebarafoods.com/recipe/results.html?q={search_word}&page="
+    url = f"https://park.ajinomoto.co.jp/recipe/search/?search_word={search_word}&tab=pop&o="
     for page in range(1, pages_num+1):
         request = requests.get(url+str(page))
         if request.status_code < 200 or request.status_code >= 300:
@@ -74,13 +75,13 @@ def scrapeRecipeUrls(soup: BeautifulSoup) -> list[str]:
     recipe_urls : list[str]
     """
     recipe_urls = []
-    # <div class="recipe--category-recipe"> から <a> タグを取得
-    # <li data-mh="list-results-item"> から <a> タグを取得
-    links = soup.select("li[data-mh='list-results-item'] a[href]")
+    links = soup.select("li.linkHover.rank div.img a[href]")
+
     for link in links:
         # link["href"]が"/recipe"から始まるURLのみを取得
-        if link["href"].startswith("/recipe"):
-            recipe_urls.append("https://www.ebarafoods.com" + link["href"])
+        # if link["href"].startswith("/recipe"):
+            # recipe_urls.append("" + link["href"])
+        recipe_urls.append(link["href"])
     return recipe_urls
 
 
@@ -99,6 +100,7 @@ def submitRecipeUrls(recipe_urls: list[str]) -> None:
         supabase.table("Urls").insert({"url": recipe_url, "structured": True}).execute()
 
 category_names = getCategories()
+category_names = category_names[0:]
 for i, category_name in enumerate(category_names):
     recipe_urls = crawlRecipeUrls(search_word=category_name, pages_num=1)
     submitRecipeUrls(recipe_urls=recipe_urls)

--- a/backend/prisma/crawl.py
+++ b/backend/prisma/crawl.py
@@ -52,9 +52,12 @@ def crawlRecipeUrls(search_word: str, pages_num: int) -> list[str]:
     # url = f"http://www.kyounoryouri.jp/search/recipe?keyword={search_word}&pg="
     # url = f"https://www.lettuceclub.net/recipe/search/{search_word}/p"
     # url = f"https://www.ebarafoods.com/recipe/results.html?q={search_word}&page="
-    url = f"https://park.ajinomoto.co.jp/recipe/search/?search_word={search_word}&tab=pop&o="
+    # url = f"https://park.ajinomoto.co.jp/recipe/search/?search_word={search_word}&tab=pop&o="
+    # url = f"https://www.ntv.co.jp/3min/search/?q={search_word}&sort=0&page="
+    # url = f"https://www.salad-cafe.com/?s={search_word}&post_type=recipe"
+    url = f"https://www.mizkan.co.jp/qssearch.jsp?searchGenre=recipe_k&indexname=MenuRecipeIndex&metainfoOption1=2&metainfoOption2=1&metainfoOption3=2&metainfoOption4=2&info_is_and=true&sort=metainfonum1+desc&searchtype=kw&limit=30&contentgroup=MenuRecipeGroup&search={search_word}&metainfo3=%2C1-1%2C&metainfo3=%2C1-2%2C&metainfo3=%2C1-3%2C&metainfo3=%2C1-4%2C&metainfo3=%2C1-5%2C&metainfo3=%2C1-6%2C&metainfo3=%2C1-7%2C&metainfo3=%2C1-8%2C"
     for page in range(1, pages_num+1):
-        request = requests.get(url+str(page))
+        request = requests.get(url) #+str(page))
         if request.status_code < 200 or request.status_code >= 300:
             break
         assert request.status_code==200
@@ -75,13 +78,13 @@ def scrapeRecipeUrls(soup: BeautifulSoup) -> list[str]:
     recipe_urls : list[str]
     """
     recipe_urls = []
-    links = soup.select("li.linkHover.rank div.img a[href]")
+    links = soup.select("div.searchRecipe_item a[href]")
 
     for link in links:
         # link["href"]が"/recipe"から始まるURLのみを取得
-        # if link["href"].startswith("/recipe"):
-            # recipe_urls.append("" + link["href"])
-        recipe_urls.append(link["href"])
+        if link["href"].startswith("/ouchirecipe/recipe"):
+            recipe_urls.append("https://www.mizkan.co.jp/" + link["href"])
+        # recipe_urls.append(link["href"])
     return recipe_urls
 
 
@@ -100,7 +103,7 @@ def submitRecipeUrls(recipe_urls: list[str]) -> None:
         supabase.table("Urls").insert({"url": recipe_url, "structured": True}).execute()
 
 category_names = getCategories()
-category_names = category_names[0:]
+category_names = category_names[:]
 for i, category_name in enumerate(category_names):
     recipe_urls = crawlRecipeUrls(search_word=category_name, pages_num=1)
     submitRecipeUrls(recipe_urls=recipe_urls)

--- a/backend/prisma/domains.json
+++ b/backend/prisma/domains.json
@@ -2,8 +2,8 @@
   "structured": [
     "✅www.kyounoryouri.jp",
     "✅www.lettuceclub.net",
-    "👹www.ebarafoods.com",
-    "park.ajinomoto.co.jp",
+    "✅www.ebarafoods.com",
+    "👹park.ajinomoto.co.jp",
     "www.ntv.co.jp/3min/",
     "www.meg-snow.com",
     "www.salad-cafe.com",

--- a/backend/prisma/domains.json
+++ b/backend/prisma/domains.json
@@ -3,22 +3,18 @@
     "✅www.kyounoryouri.jp",
     "✅www.lettuceclub.net",
     "✅www.ebarafoods.com",
-    "👹park.ajinomoto.co.jp",
-    "www.ntv.co.jp/3min/",
-    "www.meg-snow.com",
-    "www.salad-cafe.com",
-    "dancyu.jp",
-    "www.yutori.co.jp",
-    "www.marukome.co.jp",
-    "www.mizkan.co.jp",
+    "✅park.ajinomoto.co.jp",
+    "✅www.ntv.co.jp/3min/",
+    "✅www.salad-cafe.com",
+    "👹www.mizkan.co.jp",
     "kumiko-jp.com",
     "recipe.yamasa.com",
     "www.nipponham.co.jp",
     "www.kikkoman.co.jp",
     "www.sirogohan.com",
-    "www.tablemark.co.jp",
-    "www.kurashiru.com"
+    "www.tablemark.co.jp"
   ],
+  "selenium": ["www.marukome.co.jp", "dancyu.jp", "www.meg-snow.com", "www.kurashiru.com"],
   "unstructured": [
     "erecipe.woman.excite.co.jp",
     "www.momoya.co.jp",
@@ -29,5 +25,6 @@
     "www.j-oil.com",
     "www.asahimatsu.co.jp",
     "www.itoham.co.jp"
-  ]
+  ],
+  "disallow": ["www.yutori.co.jp"]
 }

--- a/backend/prisma/scrape.py
+++ b/backend/prisma/scrape.py
@@ -87,7 +87,7 @@ def findStructuredData(soup: BeautifulSoup) -> dict:
         if data is None:
             continue
         data = json.loads(data)
-        if type(data) == dict and data["@type"].lower() == "recipe":
+        if type(data) == dict and "@type" in data and data["@type"].lower() == "recipe":
             structured_data = data
             break
     return structured_data
@@ -178,7 +178,10 @@ def fixRecipeKeywords(recipe: dict) -> list[str]:
     keywords : list[str]
     """
     if "keywords" in recipe:
-        return recipe["keywords"].split(",")
+        if type(recipe["keywords"]) == list:
+            return recipe["keywords"]
+        else:
+            return recipe["keywords"].split(",")
     else:
         return []
 


### PR DESCRIPTION
# やったこと

- クローリング用の`crawl.py`とスクレイピング用の`scrape.py`を改善した

## なぜやるのか

- `domains.json`により追加したレシピサイトの進捗が確認できる
- 誰でもスクレイピングを回すことができるようになる

# 動作確認

- サイトごとに微調整がいるので、今動くのはmizkan.co.jpのみだと考えてほしい

# レビューにあたって参考にすべき情報(Optional)

- 現在の総レシピ数は 47431 です。