### PR TITLE
🔍食材検索を部分文字列でもヒットするようにした

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,7 +19,7 @@
         "@types/jest": "^29.5.1",
         "@types/supertest": "^2.0.12",
         "cors": "^2.8.5",
-        "prisma": "^3.15.1",
+        "prisma": "^5.1.1",
         "supertest": "^6.3.3",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.8.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e.tgz",
-      "integrity": "sha512-NHlojO1DFTsSi3FtEleL9QWXeSF/UjhCW0fgpi7bumnNZ4wj/eQ+BJJ5n2pgoOliTOGv9nX2qXvmHap7rJMNmg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.1.1.tgz",
+      "integrity": "sha512-NV/4nVNWFZSJCCIA3HIFJbbDKO/NARc9ej0tX5S9k2EVbkrFJC4Xt9b0u4rNZWL4V+F5LAjvta8vzEUw0rw+HA==",
       "devOptional": true,
       "hasInstallScript": true
     },
@@ -3313,9 +3313,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -3972,20 +3972,19 @@
       }
     },
     "node_modules/prisma": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.15.2.tgz",
-      "integrity": "sha512-nMNSMZvtwrvoEQ/mui8L/aiCLZRCj5t6L3yujKpcDhIPk7garp8tL4nMx2+oYsN0FWBacevJhazfXAbV1kfBzA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.1.1.tgz",
+      "integrity": "sha512-WJFG/U7sMmcc6TjJTTifTfpI6Wjoh55xl4AzopVwAdyK68L9/ogNo8QQ2cxuUjJf/Wa82z/uhyh3wMzvRIBphg==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+        "@prisma/engines": "5.1.1"
       },
       "bin": {
-        "prisma": "build/index.js",
-        "prisma2": "build/index.js"
+        "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=12.6"
+        "node": ">=16.13"
       }
     },
     "node_modules/prompts": {
@@ -4159,9 +4158,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -4466,9 +4465,9 @@
       "dev": true
     },
     "node_modules/superagent/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4632,9 +4631,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -5835,9 +5834,9 @@
       }
     },
     "@prisma/engines": {
-      "version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e.tgz",
-      "integrity": "sha512-NHlojO1DFTsSi3FtEleL9QWXeSF/UjhCW0fgpi7bumnNZ4wj/eQ+BJJ5n2pgoOliTOGv9nX2qXvmHap7rJMNmg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.1.1.tgz",
+      "integrity": "sha512-NV/4nVNWFZSJCCIA3HIFJbbDKO/NARc9ej0tX5S9k2EVbkrFJC4Xt9b0u4rNZWL4V+F5LAjvta8vzEUw0rw+HA==",
       "devOptional": true
     },
     "@prisma/engines-version": {
@@ -7561,9 +7560,9 @@
           }
         },
         "semver": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -8062,12 +8061,12 @@
       }
     },
     "prisma": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.15.2.tgz",
-      "integrity": "sha512-nMNSMZvtwrvoEQ/mui8L/aiCLZRCj5t6L3yujKpcDhIPk7garp8tL4nMx2+oYsN0FWBacevJhazfXAbV1kfBzA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.1.1.tgz",
+      "integrity": "sha512-WJFG/U7sMmcc6TjJTTifTfpI6Wjoh55xl4AzopVwAdyK68L9/ogNo8QQ2cxuUjJf/Wa82z/uhyh3wMzvRIBphg==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+        "@prisma/engines": "5.1.1"
       }
     },
     "prompts": {
@@ -8181,9 +8180,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "peer": true
     },
@@ -8419,9 +8418,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -8527,9 +8526,9 @@
           }
         },
         "semver": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "^29.5.1",
     "@types/supertest": "^2.0.12",
     "cors": "^2.8.5",
-    "prisma": "^3.15.1",
+    "prisma": "^5.1.1",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.8.1"

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["fullTextSearch"]
 }
 
 datasource db {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,14 +22,15 @@ model Categories {
 }
 
 model Recipes {
-  id                Int      @id @default(autoincrement())
-  recipeTitle       String
-  recipeUrl         String
-  recipeDescription String
-  foodImageUrls     String[]
-  keywords          String[]
-  totalTime         Int
-  recipeMaterial    String[]
+  id                      Int      @id @default(autoincrement())
+  recipeTitle             String
+  recipeUrl               String
+  recipeDescription       String
+  foodImageUrls           String[]
+  keywords                String[]
+  totalTime               Int
+  recipeMaterial          String[]
+  recipeMaterialConverted String?
 }
 
 model RecipesTmp {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -29,10 +29,11 @@ app.post("/searchRecipes", async (request, response) => {
   const searchInfo: SearchInfo = request.body.content
   console.log(searchInfo.ingredient) // こういう風にデバッグできます。backendのターミナルで見てみてください
 
+  const ingredientsAndQuery: string = searchInfo.ingredient.join(" & ")
   const results = await client.recipes.findMany({
     where: {
-      recipeMaterial: {
-        hasEvery: searchInfo.ingredient,
+      recipeMaterialConverted: {
+        search: ingredientsAndQuery,
       },
     },
     take: 20,


### PR DESCRIPTION
## やったこと

- Supabaseの`Recipes`テーブルに、`recipeMaterial`をString型にしただけの`recipeMaterialConverted`を作成
- Prismaに導入された[全文検索](https://www.prisma.io/docs/concepts/components/prisma-client/full-text-search)を用いて、部分文字列の検索を導入した
- 食材の`hasEvery`を`searchInfo.ingredient`を&クエリに変更

## なぜやるのか

- 食材検索がまともにできなかったため

## 動作確認

- 例えば「なす」「豚肉」で検索すると、食材になすと豚肉を含むものが検索できた

## レビューにあたって参考にすべき情報(Optional)

- `recipeMaterialConverted`列は2行のSQLを書いて作成した