### PR TITLE
🇬Enable to sign in with google account / sign out

### DIFF
--- a/frontend/src/features/Auth/Auth.tsx
+++ b/frontend/src/features/Auth/Auth.tsx
@@ -1,9 +1,23 @@
 import { Session } from "@supabase/supabase-js"
+import { supabase } from "./supabaseClient"
 import { SignIn } from "./SignIn"
+
 interface Props {
   session: Session | null
 }
 
 export const Auth = (props: Props) => {
-  return !props.session ? <SignIn /> : <div>Already logged in</div>
+  async function signOut() {
+    const { error } = await supabase.auth.signOut()
+    if (error) console.log(error.message)
+  }
+
+  return !props.session ? (
+    <SignIn />
+  ) : (
+    <div>
+      <p>Already logged in</p>
+      <button onClick={signOut}>Sign out</button>
+    </div>
+  )
 }

--- a/frontend/src/features/Auth/SignIn/SignIn.tsx
+++ b/frontend/src/features/Auth/SignIn/SignIn.tsx
@@ -19,29 +19,37 @@ export const SignIn = () => {
     setLoading(false)
   }
 
+  const onClickLoginWithGoogle = async () => {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        queryParams: {
+          access_type: "offline",
+          prompt: "consent",
+        },
+      },
+    })
+    if (error) {
+      alert(error.message)
+    }
+  }
+
   return (
-    <div className="row flex flex-center">
-      <div className="col-6 form-widget">
-        <h1 className="header">Supabase + React</h1>
-        <p className="description">Sign in via magic link with your email below</p>
-        <form className="form-widget" onSubmit={handleLogin}>
-          <div>
-            <input
-              className="inputField"
-              type="email"
-              placeholder="Your email"
-              value={email}
-              required={true}
-              onChange={(e) => setEmail(e.target.value)}
-            />
-          </div>
-          <div>
-            <button className={"button block"} disabled={loading}>
-              {loading ? <span>Loading</span> : <span>Send magic link</span>}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+    <>
+      <h1>ログイン</h1>
+      <p>Sign in via magic link with your email below</p>
+      <form onSubmit={handleLogin}>
+        <input
+          type="email"
+          placeholder="Your email"
+          value={email}
+          required={true}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <button disabled={loading}>{loading ? <span>Loading</span> : <span>Send magic link</span>}</button>
+      </form>
+      <p>or</p>
+      <button onClick={onClickLoginWithGoogle}>Sign in with Google Account</button>
+    </>
   )
 }


### PR DESCRIPTION
#161 

## やったこと

- `/auth`にサインアウトボタンを追加した
- Google OAuthキーを作成し、Supabaseと接続してGoogleアカウントでログインできるようにした

## なぜやるのか

- Googleアカウントを使ったログイン機能はユーザに価値を届けるために必要な機能であるから

## 動作確認

- Emailログイン情報をリセットした後、`localhost:5173/auth`にアクセスして、サインインを試した

## レビューにあたって参考にすべき情報(Optional)

- Googleアカウントのログインページがやや怪しく見えてしまいます
![image](https://github.com/ut-code/menu/assets/53532178/d4823ae1-de6a-45b6-864f-89855e440f82)