### PR TITLE
🔑Create public.Users table on supabase

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -49,3 +49,11 @@ model Urls {
   url String
   structured Boolean
 }
+
+model Users {
+	id String @id
+	email String @unique
+	createdAt DateTime @default(now())
+	updatedAt DateTime @updatedAt
+	favorites Int[]
+}


### PR DESCRIPTION
#161 

## やったこと

- `schema.prisma`で、ユーザーのuidとemailをキーとし、ユーザー情報を保管するUsersテーブルを定義した
- Supabaseでtriggerを作成し、auth.usersテーブルとpublic.Usersテーブルが同期して作成・削除できるようにした

## なぜやるのか

- ユーザー情報を保管しておくことでRecommend機能等に使用できるが、ユーザーに最適化する機能は価値を届けるために必要な機能であるから

## 動作確認

- `localhost:5173/auth`にアクセスして、EmailによるマジックリンクのログインとGoogleアカウントによるログインを試した。すると、Usersテーブルに作成された。
- Supabase上でauth.usersからユーザーを削除すると、Usersテーブルからも削除された