### PR TITLE
🔑Enable to delete account from client

### DIFF
--- a/frontend/src/features/Auth/Auth.tsx
+++ b/frontend/src/features/Auth/Auth.tsx
@@ -1,23 +1,18 @@
 import { Session } from "@supabase/supabase-js"
-import { supabase } from "./supabaseClient"
 import { SignIn } from "./SignIn"
+import { SignOut } from "./SignOut"
 
 interface Props {
   session: Session | null
 }
 
 export const Auth = (props: Props) => {
-  async function signOut() {
-    const { error } = await supabase.auth.signOut()
-    if (error) console.log(error.message)
-  }
-
   return !props.session ? (
     <SignIn />
   ) : (
     <div>
       <p>Already logged in</p>
-      <button onClick={signOut}>Sign out</button>
+      <SignOut />
     </div>
   )
 }

--- a/frontend/src/features/Auth/Auth.tsx
+++ b/frontend/src/features/Auth/Auth.tsx
@@ -1,6 +1,7 @@
 import { Session } from "@supabase/supabase-js"
 import { SignIn } from "./SignIn"
 import { SignOut } from "./SignOut"
+import { DeleteAccount } from "./DeleteAccount"
 
 interface Props {
   session: Session | null
@@ -13,6 +14,8 @@ export const Auth = (props: Props) => {
     <div>
       <p>Already logged in</p>
       <SignOut />
+      <br />
+      <DeleteAccount />
     </div>
   )
 }

--- a/frontend/src/features/Auth/Auth.tsx
+++ b/frontend/src/features/Auth/Auth.tsx
@@ -15,7 +15,7 @@ export const Auth = (props: Props) => {
       <p>Already logged in</p>
       <SignOut />
       <br />
-      <DeleteAccount />
+      <DeleteAccount session={props.session} />
     </div>
   )
 }

--- a/frontend/src/features/Auth/DeleteAccount/DeleteAccount.tsx
+++ b/frontend/src/features/Auth/DeleteAccount/DeleteAccount.tsx
@@ -1,16 +1,26 @@
 import { useState } from "react"
-// import { supabase } from "../supabaseClient"
+import { Session } from "@supabase/supabase-js"
+import { supabase } from "../supabaseClient"
 
-export const DeleteAccount = () => {
+interface Props {
+  session: Session | null
+}
+
+export const DeleteAccount = (props: Props) => {
   const [loading, setLoading] = useState(false)
 
   const handleDeleteAccount = async () => {
     setLoading(true)
-    // const { error } = await supabase.auth.signOut()
+    const userId = props.session?.user?.id
+    if (!userId) return
 
-    // if (error) {
-    //   alert(error.message)
-    // }
+    const [deleteResult, signOutResult] = await Promise.all([
+      supabase.from("Users").delete().eq("id", userId),
+      supabase.auth.signOut(),
+    ])
+    if (deleteResult.error) alert(deleteResult.error.message)
+    if (signOutResult.error) alert(signOutResult.error.message)
+
     setLoading(false)
   }
 

--- a/frontend/src/features/Auth/DeleteAccount/DeleteAccount.tsx
+++ b/frontend/src/features/Auth/DeleteAccount/DeleteAccount.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react"
+// import { supabase } from "../supabaseClient"
+
+export const DeleteAccount = () => {
+  const [loading, setLoading] = useState(false)
+
+  const handleDeleteAccount = async () => {
+    setLoading(true)
+    // const { error } = await supabase.auth.signOut()
+
+    // if (error) {
+    //   alert(error.message)
+    // }
+    setLoading(false)
+  }
+
+  return (
+    <button disabled={loading} onClick={handleDeleteAccount}>
+      {loading ? <span>Loading</span> : <span>Delete Account</span>}
+    </button>
+  )
+}

--- a/frontend/src/features/Auth/DeleteAccount/index.ts
+++ b/frontend/src/features/Auth/DeleteAccount/index.ts
@@ -1,0 +1,1 @@
+export { DeleteAccount } from "./DeleteAccount"

--- a/frontend/src/features/Auth/SignIn/SignIn.tsx
+++ b/frontend/src/features/Auth/SignIn/SignIn.tsx
@@ -5,7 +5,7 @@ export const SignIn = () => {
   const [loading, setLoading] = useState(false)
   const [email, setEmail] = useState("")
 
-  const handleLogin = async (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSignIn = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
 
     setLoading(true)
@@ -38,7 +38,7 @@ export const SignIn = () => {
     <>
       <h1>ログイン</h1>
       <p>Sign in via magic link with your email below</p>
-      <form onSubmit={handleLogin}>
+      <form onSubmit={handleSignIn}>
         <input
           type="email"
           placeholder="Your email"

--- a/frontend/src/features/Auth/SignOut/SignOut.tsx
+++ b/frontend/src/features/Auth/SignOut/SignOut.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react"
+import { supabase } from "../supabaseClient"
+
+export const SignOut = () => {
+  const [loading, setLoading] = useState(false)
+
+  const handleSignOut = async () => {
+    setLoading(true)
+    const { error } = await supabase.auth.signOut()
+
+    if (error) {
+      alert(error.message)
+    }
+    setLoading(false)
+  }
+
+  return (
+    <button disabled={loading} onClick={handleSignOut}>
+      {loading ? <span>Loading</span> : <span>Sign out</span>}
+    </button>
+  )
+}

--- a/frontend/src/features/Auth/SignOut/index.ts
+++ b/frontend/src/features/Auth/SignOut/index.ts
@@ -1,0 +1,1 @@
+export { SignOut } from "./SignOut"


### PR DESCRIPTION
#161 

## やったこと

- サインインした状態で`/auth`でDelete Accountを押すと、Usersテーブルからアカウント情報が削除できるようにした
- Row Level Securityを使用して、client側から削除者と削除したいアカウントが一致した場合にのみ削除ができるようにした
- Supabaseでtriggerを更新し、Userテーブルからアカウント情報を削除すると、auth.usersからも削除されるようにした

## なぜやるのか

- 退会機能はユーザーに価値を届ける（ユーザーの不満を軽減する）ために必要な機能であるから

## 動作確認

- サインインした状態で`localhost:5173/auth`にアクセスして、Delete Accountを押すと、Usersテーブル、auth.usersからユーザー登録が削除された