### PR TITLE
🍎食材の質問を1つに合体させる・Questionsのリファクタリング

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -19,7 +19,7 @@ app.use(express.json())
 //----------------------------------------------------------------
 // request.bodyのsearchInfoを利用して検索結果を返す
 type SearchInfo = {
-  ingredient: string[]
+  ingredients: string[]
   time?: string
   dish?: string // 主菜・副菜など
   keywords?: string[]
@@ -27,9 +27,9 @@ type SearchInfo = {
 
 app.post("/searchRecipes", async (request, response) => {
   const searchInfo: SearchInfo = request.body.content
-  console.log(searchInfo.ingredient) // こういう風にデバッグできます。backendのターミナルで見てみてください
+  console.log(searchInfo.ingredients) // こういう風にデバッグできます。backendのターミナルで見てみてください
 
-  const ingredientsAndQuery: string = searchInfo.ingredient.join(" & ")
+  const ingredientsAndQuery: string = searchInfo.ingredients.join(" & ")
   const results = await client.recipes.findMany({
     where: {
       recipeMaterialConverted: {

--- a/frontend/src/features/Home/Home.tsx
+++ b/frontend/src/features/Home/Home.tsx
@@ -4,9 +4,9 @@ import { useEffect } from "react"
 export const Home = () => {
   // 永続的に残るので、localStorageから問題への回答を消しておく
   useEffect(() => {
-    for (let i = 0; i < 4; i++) {
-      localStorage.removeItem("answer-" + i.toString())
-    }
+    localStorage.removeItem("ingredients")
+    localStorage.removeItem("genre")
+    localStorage.removeItem("cookingTime")
   }, [])
 
   return (

--- a/frontend/src/features/Questions/Questions.tsx
+++ b/frontend/src/features/Questions/Questions.tsx
@@ -119,14 +119,6 @@ const questions: Question[] = [
       2: { choiceText: "じっくり", choiceImage: "" },
     },
   },
-  {
-    questionNumber: 3,
-    questionText: "他に使いたい食材はありますか？",
-    userInput: true,
-    choices: {
-      0: { choiceText: "豚肉", choiceImage: imgPork },
-    },
-  },
 ]
 type Answer = {
   answerNumber: number

--- a/frontend/src/features/Questions/Questions.tsx
+++ b/frontend/src/features/Questions/Questions.tsx
@@ -43,6 +43,7 @@ type Question = {
   questionText: string
   userInput: boolean
   choices: Choices
+  questionType: "ingredients" | "genre" | "cookingTime"
 }
 //----------------------------------------------------------------
 // 質問を配列で定義
@@ -97,6 +98,7 @@ const questions: Question[] = [
       2: { choiceText: randomFoods[2].choiceText, choiceImage: randomFoods[2].choiceImage },
       3: { choiceText: randomFoods[3].choiceText, choiceImage: randomFoods[3].choiceImage },
     },
+    questionType: "ingredients",
   },
   {
     questionNumber: 1,
@@ -108,6 +110,7 @@ const questions: Question[] = [
       2: { choiceText: "汁物", choiceImage: "" },
       3: { choiceText: "その他", choiceImage: "" },
     },
+    questionType: "genre",
   },
   {
     questionNumber: 2,
@@ -118,18 +121,29 @@ const questions: Question[] = [
       1: { choiceText: "普通", choiceImage: "" },
       2: { choiceText: "じっくり", choiceImage: "" },
     },
+    questionType: "cookingTime",
   },
 ]
-type Answer = {
-  answerNumber: number
-  content: string
+
+type Answers = {
+  ingredients: string[]
+  genre: string
+  cookingTime: string
 }
 
 export const Questions = () => {
   const [currentQuestion, setCurrentQuestion] = useState<Question>(questions[0])
   const [inputContent, setInputContent] = useState<string>("")
-  const [answers, setAnswers] = useState<Answer[]>([])
   const [isOpenHamburger, setIsOpenHamburger] = useState<boolean>(false)
+
+  const [ingredients, setIngredients] = useState<string[]>([])
+  const [genre, setGenre] = useState<string>("")
+  const [cookingTime, setCookingTime] = useState<string>("")
+  const answers: Answers = {
+    ingredients: ingredients,
+    genre: genre,
+    cookingTime: cookingTime,
+  }
 
   // useNavigate を Navigate に変化させる呪文
   const Navigate = useNavigate()
@@ -138,20 +152,29 @@ export const Questions = () => {
   // localStorage を使って inputContent と currentQuestion を設定する
   //----------------------------------------------------------------
   useEffect(() => {
-    for (let i = 0; i < questions.length; i++) {
-      const answer = localStorage.getItem("answer-" + i.toString())
+    questions.forEach((question) => {
+      const answer = localStorage.getItem(question.questionType)
       if (answer !== null) {
-        setCurrentQuestion(questions[i])
-        setInputContent(answer)
+        setCurrentQuestion(question)
+        switch (question.questionType) {
+          case "ingredients":
+            setIngredients(JSON.parse(answer))
+            break
+          case "genre":
+            setGenre(answer)
+            break
+          case "cookingTime":
+            setCookingTime(answer)
+        }
       }
-    }
+    })
   }, [])
 
   //----------------------------------------------------------------
   // currentQuestionの変更をフックにして回答状況を復元
   //----------------------------------------------------------------
   useEffect(() => {
-    const answer = localStorage.getItem("answer-" + currentQuestion.questionNumber.toString())
+    const answer = localStorage.getItem(currentQuestion.questionType)
     if (answer !== null) {
       setInputContent(answer)
     }
@@ -165,7 +188,16 @@ export const Questions = () => {
     setInputContent(e.target.value)
 
     // 問題番号をキーにして、選んだ選択肢をlocalStorageに保存
-    localStorage.setItem("answer-" + currentQuestion.questionNumber.toString(), e.target.value)
+    switch (currentQuestion.questionType) {
+      case "ingredients":
+        setIngredients([e.target.value])
+        break
+      case "genre":
+        setGenre(e.target.value)
+        break
+      case "cookingTime":
+        setCookingTime(e.target.value)
+    }
   }
 
   //----------------------------------------------------------------
@@ -181,7 +213,16 @@ export const Questions = () => {
       alert("選択肢を選んでください")
       return
     } else {
-      localStorage.setItem("answer-" + currentQuestion.questionNumber.toString(), inputContent)
+      switch (currentQuestion.questionType) {
+        case "ingredients":
+          localStorage.setItem(currentQuestion.questionType, JSON.stringify(ingredients))
+          break
+        case "genre":
+          localStorage.setItem(currentQuestion.questionType, genre)
+          break
+        case "cookingTime":
+          localStorage.setItem(currentQuestion.questionType, cookingTime)
+      }
     }
     setInputContent("")
 
@@ -205,18 +246,24 @@ export const Questions = () => {
     setIsOpenHamburger(false)
   }
 
-  useEffect(() => {
-    // localStorageから解答を取り出してanswersに入れる
-    const newAnswers: Answer[] = []
-    for (let i = 0; i < questions.length; i++) {
-      const answer = localStorage.getItem("answer-" + i.toString())
-      if (answer !== null) {
-        // addAnswer({ answerNumber: i, content: answer })
-        newAnswers.push({ answerNumber: i, content: answer })
-      }
-    }
-    setAnswers(newAnswers)
-  }, [currentQuestion])
+  // useEffect(() => {
+  //   // localStorageから解答を取り出してanswersに入れる
+  //   questions.forEach((question) => {
+  //     const answer = localStorage.getItem(question.questionType)
+  //     if (answer !== null) {
+  //       switch (question.questionType) {
+  //         case "ingredients":
+  //           setIngredients(JSON.parse(answer))
+  //           break
+  //         case "genre":
+  //           setGenre(answer)
+  //           break
+  //         case "cookingTime":
+  //           setCookingTime(answer)
+  //       }
+  //     }
+  //   })
+  // }, [currentQuestion])
 
   return (
     <>

--- a/frontend/src/features/Questions/components/Keywords/Keywords.tsx
+++ b/frontend/src/features/Questions/components/Keywords/Keywords.tsx
@@ -13,12 +13,7 @@ export const Keywords = ({ answers }: Props) => {
     <div className={styles.box}>
       <span className={styles.title}>あなたの検索ワード🔍&nbsp;&nbsp;</span>
       <br></br>
-      <div className={styles.text}>
-        {/* {props.answers.map((answer, index) => (
-          <span key={index}>{answer.content}&nbsp;</span>
-        ))} */}
-        {[...answers.ingredients, answers.genre, answers.cookingTime].join(" ")}
-      </div>
+      <div className={styles.text}>{[...answers.ingredients, answers.genre, answers.cookingTime].join(" ")}</div>
     </div>
   )
 }

--- a/frontend/src/features/Questions/components/Keywords/Keywords.tsx
+++ b/frontend/src/features/Questions/components/Keywords/Keywords.tsx
@@ -1,19 +1,23 @@
 import styles from "./Keywords.module.css"
 
-type Answer = {
-  answerNumber: number
-  content: string
+interface Props {
+  answers: {
+    ingredients: string[]
+    genre: string
+    cookingTime: string
+  }
 }
 
-export const Keywords = (props: { answers: Answer[] }) => {
+export const Keywords = ({ answers }: Props) => {
   return (
     <div className={styles.box}>
       <span className={styles.title}>あなたの検索ワード🔍&nbsp;&nbsp;</span>
       <br></br>
       <div className={styles.text}>
-        {props.answers.map((answer, index) => (
+        {/* {props.answers.map((answer, index) => (
           <span key={index}>{answer.content}&nbsp;</span>
-        ))}
+        ))} */}
+        {[...answers.ingredients, answers.genre, answers.cookingTime].join(" ")}
       </div>
     </div>
   )

--- a/frontend/src/features/Result/Result.tsx
+++ b/frontend/src/features/Result/Result.tsx
@@ -20,13 +20,14 @@ type Recipe = {
   recipeMaterialConverted: string
 }
 
-type Answer = {
-  answerNumber: number
-  content: string
+type Answers = {
+  ingredients: string[]
+  genre: string
+  cookingTime: string
 }
 
 type SearchInfo = {
-  ingredient: string[]
+  ingredients: string[]
   time?: string
   dish?: string // 主菜・副菜など
   keywords: string[]
@@ -42,14 +43,10 @@ export const Result = () => {
   const [runEffect, setRunEffect] = useState<boolean>(false)
   const [isOpenHamburger, setIsOpenHamburger] = useState<boolean>(false)
 
-  const convertAnswersToSearchInfo = (answers: Answer[]): SearchInfo => {
-    const info: SearchInfo = { ingredient: [], keywords: [] }
+  const convertAnswersToSearchInfo = (answers: Answers): SearchInfo => {
+    const info: SearchInfo = { ingredients: [], keywords: [] }
     if (answers) {
-      answers.forEach((answer: Answer) => {
-        // answer.contentをingredientに追加
-        if (answer.answerNumber === 0) info.ingredient.push(answer.content)
-        if (answer.answerNumber === 3) info.ingredient.push(answer.content)
-      })
+      info.ingredients = answers.ingredients
     }
     return info
   }
@@ -61,18 +58,16 @@ export const Result = () => {
     unmounted = true
 
     // localStorageから解答を取り出してanswersに入れる
-    const answers: Answer[] = []
-    for (let i = 0; i < 4; i++) {
-      const answer = localStorage.getItem("answer-" + i.toString())
-      if (answer !== null) {
-        answers.push({ answerNumber: i, content: answer })
-      }
+    const answers: Answers = {
+      ingredients: JSON.parse(localStorage.getItem("ingredients") || "[]"),
+      genre: localStorage.getItem("genre") || "",
+      cookingTime: localStorage.getItem("cookingTime") || "",
     }
 
     // inputContent の初期値を設定
     // answers を空白区切りで連結したものをsetInputContent
     // 例: ["豚肉", "玉ねぎ", "にんにく"] -> "豚肉 玉ねぎ にんにく"
-    setInputContent(answers.map((answer) => answer.content).join(" "))
+    setInputContent([...answers.ingredients, answers.genre, answers.cookingTime].join(" "))
 
     // answers をfindManyの検索に使いやすいように searchInfo に整形
     const searchInfo: SearchInfo = convertAnswersToSearchInfo(answers)
@@ -109,7 +104,7 @@ export const Result = () => {
   //----------------------------------------------------------------
   const convertInputContentToSearchInfo = (newInputContent: string): SearchInfo => {
     // inputContentを使ったフリーワード検索を行う
-    const info: SearchInfo = { ingredient: [], keywords: [] }
+    const info: SearchInfo = { ingredients: [], keywords: [] }
     // newInputContentを空白区切りで配列にする
     const searchWords: string[] = newInputContent.split(" ")
 


### PR DESCRIPTION
#177 #157 

## やったこと

- localStorageに回答を保存するときのキーを文字列にした
- 食材を配列で保存した

## なぜやるのか

- onChangeでlocalStorageに保存するのはパフォーマンスの観点から望ましくないため
- 食材を配列で保存するのは、食材の複数検索をする前提だから

## 動作確認

- 通常通り検索を試した

## レビューにあたって参考にすべき情報(Optional)

- 1問目の検索窓は配列の形で表示されてしまう（改良はUIを待ってからでよさそう）