### PR TITLE
fix: localStorageに回答に対応するキーが存在しないときのエラーを修正

### DIFF
--- a/frontend/src/features/Result/Result.tsx
+++ b/frontend/src/features/Result/Result.tsx
@@ -29,16 +29,19 @@ export const Result = ({ session }: Props) => {
   const [isOpenHamburger, setIsOpenHamburger] = useState<boolean>(false)
   const queryClient = useQueryClient()
 
+  const storedIngredients = localStorage.getItem("ingredients")
+  const storedGenre = localStorage.getItem("genre")
+  const storedCookingTime = localStorage.getItem("cookingTime")
   const answers: Answers = {
-    ingredients: JSON.parse(localStorage.getItem("ingredients") || "[]"),
-    genre: JSON.parse(localStorage.getItem("genre") || ""),
-    cookingTime: JSON.parse(localStorage.getItem("cookingTime") || ""),
+    ingredients: storedIngredients ? JSON.parse(storedIngredients) : [],
+    genre: storedGenre ? JSON.parse(storedGenre) : null,
+    cookingTime: storedCookingTime ? JSON.parse(storedCookingTime) : null,
   }
-  // answers をfindManyの検索に使いやすいように searchInfo に整形
+  // NOTE: answers をfindManyの検索に使いやすいように searchInfo に整形
   const searchInfo: SearchInfo = convertAnswersToSearchInfo(answers)
 
   useEffect(() => {
-    // answers を空白区切りで連結したものをsetInputContent
+    // NOTE: answers を空白区切りで連結したものをsetInputContent
     // 例: ["豚肉", "玉ねぎ", "にんにく"] -> "豚肉 玉ねぎ にんにく"
     setInputContent([...answers.ingredients, answers.genre, answers.cookingTime].join(" "))
   }, [])

--- a/frontend/src/utils/recipes.ts
+++ b/frontend/src/utils/recipes.ts
@@ -11,21 +11,21 @@ export type Recipe = {
 
 export type Answers = {
   ingredients: string[]
-  genre: string
-  cookingTime: string
+  genre: string | null
+  cookingTime: string | null
 }
 
 export type SearchInfo = {
   ingredients: string[]
-  time?: string
-  dish?: string // 主菜・副菜など
+  time: string | null
+  dish: string | null // 主菜・副菜など
 }
 
 export const convertAnswersToSearchInfo = (answers: Answers): SearchInfo => {
-  const info: SearchInfo = { ingredients: [], time: "" }
-  if (answers) {
-    info.ingredients = answers.ingredients
-    info.time = answers.cookingTime
+  const info: SearchInfo = {
+    ingredients: answers.ingredients,
+    time: answers.cookingTime,
+    dish: answers.genre,
   }
   return info
 }


### PR DESCRIPTION
## やったこと
- recipes.tsの型であるAnswers, SearchInfoをnull許容に
- JSON.parse前にnullかどうかを確認する

## なぜやるのか
- 食材を聞かれたタイミングで検索アイコンを押すとエラーが出ていたため。