### PR TITLE
[Backend] キーワードが空白文字のみのときのエラーを直した

### DIFF
--- a/backend/src/controllers/SearchController.ts
+++ b/backend/src/controllers/SearchController.ts
@@ -40,11 +40,11 @@ class SearchController {
   }
 
   searchRecipesByKeywords = async (req: Request, res: Response): Promise<void> => {
-    const { keywords } = req.body
-    const keywordsOrQuery = this.joinKeywords(keywords)
-    console.error(keywordsOrQuery)
     try {
       // FIXME: 関連性のある結果が全く得られない
+      const { keywords } = req.body
+      const keywordsOrQuery = this.joinKeywords(keywords)
+
       const recipes = await client.recipes.findMany({
         orderBy: {
           _relevance: {
@@ -55,7 +55,6 @@ class SearchController {
         },
         take: 20,
       })
-      console.log(recipes)
       res.json(recipes)
     } catch (error) {
       console.error(error)

--- a/backend/src/controllers/SearchController.ts
+++ b/backend/src/controllers/SearchController.ts
@@ -40,10 +40,10 @@ class SearchController {
   }
 
   searchRecipesByKeywords = async (req: Request, res: Response): Promise<void> => {
+    const { keywords } = req.body
+    const keywordsOrQuery = this.joinKeywords(keywords)
+    console.error(keywordsOrQuery)
     try {
-      const { keywords } = req.body
-      const keywordsOrQuery = this.joinKeywords(keywords)
-      console.log(keywordsOrQuery)
       // FIXME: 関連性のある結果が全く得られない
       const recipes = await client.recipes.findMany({
         orderBy: {
@@ -86,8 +86,11 @@ class SearchController {
     return { orderBy, orderDir }
   }
 
-  private joinKeywords = (keywords: string): string => {
-    return keywords.replace(/\s+/g, " | ")
+  private joinKeywords = (keywords: string | null): string => {
+    // FIXME: keywords が空白のみのときのエラーを無理やり回避している
+    const keywordsFiltered = keywords?.replace(/\s{2,}/g, " ")
+    if (!keywordsFiltered || keywordsFiltered === " ") return ""
+    return keywordsFiltered.replace(/\s+/g, " | ")
   }
 }
 


### PR DESCRIPTION
#266 
## やったこと
- 取り急ぎ、keywordsの2個以上の空白文字を正規表現で一個に置き換えて、その後に" | "に置き換える操作をした